### PR TITLE
Added libgamma.so to make_mac.csh

### DIFF
--- a/lib/fortran/make_mac.csh
+++ b/lib/fortran/make_mac.csh
@@ -10,6 +10,7 @@ $gf -dynamiclib -o libne2001.so -fno-second-underscore ne2001.o dm.o psr_ne.o di
 $gf -dynamiclib -o libykarea.so -fno-second-underscore ykarea.o psrran.o
 $gf -dynamiclib -o libsla.so -fno-second-underscore galtfeq.o sla.o
 $gf -dynamiclib -o libvxyz.so -fno-second-underscore vxyz.o rkqc.o rk4.o
+$gf -dynamiclib -o libgamma.so -fno-second-underscore gamma.o
 
 
 rm *.o

--- a/lib/fortran/psr_normal.f
+++ b/lib/fortran/psr_normal.f
@@ -11,5 +11,5 @@ c
       rnd2 = psrran(seed)
       if (rnd1 .eq. 0.0) rnd1 = psrran(seed)
       psr_normal = ((sigma * ((- (2.0 * log(rnd1))) ** 0.5)) 
-     &               * cos((2.0 * +  3.1415926) * rnd2)) + mu
+     &               * cos((2.0 * 3.1415926) * rnd2)) + mu
       end


### PR DESCRIPTION
Following the tutorial, this example does not work:

$ python populate.py -n 1038 -surveys PMSURV

That's because in the make_mac.csh there was a missing libgamma.so.


