### PR TITLE
fix hardcoded paths to python interpreter

### DIFF
--- a/bin/old_viewing_software/qtView.py
+++ b/bin/old_viewing_software/qtView.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import os

--- a/bin/old_viewing_software/tkView.py
+++ b/bin/old_viewing_software/tkView.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import os

--- a/bin/old_viewing_software/visualize.py
+++ b/bin/old_viewing_software/visualize.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import argparse
@@ -12,8 +12,8 @@ from matplotlib.widgets import Button, RadioButtons, CheckButtons
 
 import numpy as np
 
-from population import Population 
-from pulsar import Pulsar
+from psrpoppy.population import Population 
+from psrpoppy.pulsar import Pulsar
 
 
 class Visualize:

--- a/bin/popheader
+++ b/bin/popheader
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import cPickle
 

--- a/bin/popjoin
+++ b/bin/popjoin
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import argparse

--- a/bin/wxHist
+++ b/bin/wxHist
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import os
@@ -17,7 +17,7 @@ from matplotlib.backends.backend_wxagg import \
     FigureCanvasWxAgg as FigCanvas, \
     NavigationToolbar2WxAgg as NavigationToolbar
 
-import dataobj
+from psrpoppy import dataobj
 
 class ViewException(Exception):
     pass

--- a/bin/wxView
+++ b/bin/wxView
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import os
@@ -16,7 +16,7 @@ from matplotlib.backends.backend_wxagg import \
     FigureCanvasWxAgg as FigCanvas, \
     NavigationToolbar2WxAgg as NavigationToolbar
 
-import dataobj 
+from psrpoppy import dataobj 
 
 class ViewException(Exception):
     pass

--- a/psrpoppy/dosurvey.py
+++ b/psrpoppy/dosurvey.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import argparse

--- a/psrpoppy/evolve.py
+++ b/psrpoppy/evolve.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import argparse

--- a/psrpoppy/populate.py
+++ b/psrpoppy/populate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import argparse


### PR DESCRIPTION
The hardcoded paths to the Python interpreter prevented the use of PsrPopPy with e.g. the Anaconda Python Distribution. I'm proposing to replace them with the correct line:
```
#!/usr/bin/env python
```