### PR TITLE
Python 2 to 3 conversion

### DIFF
--- a/psrpoppy/beaming.py
+++ b/psrpoppy/beaming.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function, division, absolute_import
+
 import os
 import sys
 import math

--- a/psrpoppy/dataobj.py
+++ b/psrpoppy/dataobj.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function, division, absolute_import
+
 import os
 import sys
 

--- a/psrpoppy/dataobj.py
+++ b/psrpoppy/dataobj.py
@@ -1,8 +1,12 @@
 #!/usr/bin/python
 
 import os
+import sys
 
-import cPickle
+if sys.version_info[0] == 3:
+    import pickle
+else:
+    import cPickle as pickle
 
 
 class DataObj:
@@ -46,13 +50,13 @@ def readfile_return_dataobj(filename):
     try:
         f = open(filename, 'rb')
     except IOError:
-        print "Could not open file {0}.".format(filename)
+        print("Could not open file {0}.".format(filename))
         return
 
     try:
-        pop = cPickle.load(f)
-    except cPickle.UnpicklingError:
-        print "File {0} could not be unpickled!".format(filename)
+        pop = pickle.load(f)
+    except pickle.UnpicklingError:
+        print("File {0} could not be unpickled!".format(filename))
         return
     f.close()
 

--- a/psrpoppy/degradation.py
+++ b/psrpoppy/degradation.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function, division, absolute_import
+
 import os
 
 import ctypes as C

--- a/psrpoppy/distributions.py
+++ b/psrpoppy/distributions.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function, division, absolute_import
+
 import sys
 import math
 import random

--- a/psrpoppy/dosurvey.py
+++ b/psrpoppy/dosurvey.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function, division, absolute_import
+
 import sys
 import argparse
 import math

--- a/psrpoppy/dosurvey.py
+++ b/psrpoppy/dosurvey.py
@@ -5,13 +5,17 @@ import argparse
 import math
 import random
 
-import cPickle
+if sys.version_info[0] == 3:
+    import pickle
+else:
+    import cPickle as pickle
+
 
 try:
     # try and import from the current path (for package usage or use as an uninstalled executable)
-    from population import Population
-    from pulsar import Pulsar
-    from survey import Survey
+    from .population import Population
+    from .pulsar import Pulsar
+    from .survey import Survey
 except:
     try:
         # import from the installed package
@@ -42,7 +46,7 @@ def loadModel(popfile='populate.model', popmodel=None):
        or pass in a model from memory (popmodel)"""
     if popmodel is None:
         with open(popfile, 'rb') as f:
-            pop = cPickle.load(f)
+            pop = pickle.load(f)
     else:
         pop = popmodel
 
@@ -97,8 +101,8 @@ def run(pop,
 
     # print the population
     if not nostdout:
-        print "Running doSurvey on population..."
-        print pop
+        print("Running doSurvey on population...")
+        print(pop)
 
     # loop over the surveys we want to run on the pop file
     surveyPops = []
@@ -106,7 +110,7 @@ def run(pop,
         s = Survey(surv)
         s.discoveries = 0
         if not nostdout:
-            print "\nRunning survey {0}".format(surv)
+            print("\nRunning survey {0}".format(surv))
 
         # create a new population object to store discovered pulsars in
         survpop = Population()
@@ -154,13 +158,13 @@ def run(pop,
 
         # report the results
         if not nostdout:
-            print "Total pulsars in model = {0}".format(len(pop.population))
-            print "Number detected by survey {0} = {1}".format(surv, ndet)
-            print "Of which are discoveries = {0}".format(s.discoveries)
-            print "Number too faint = {0}".format(ntf)
-            print "Number smeared = {0}".format(nsmear)
-            print "Number out = {0}".format(nout)
-            print "\n"
+            print("Total pulsars in model = {0}".format(len(pop.population)))
+            print("Number detected by survey {0} = {1}".format(surv, ndet))
+            print("Of which are discoveries = {0}".format(s.discoveries))
+            print("Number too faint = {0}".format(ntf))
+            print("Number smeared = {0}".format(nsmear))
+            print("Number out = {0}".format(nout))
+            print("\n")
 
         d = Detections(ndet=ndet,
                        ntf=ntf,

--- a/psrpoppy/evolve.py
+++ b/psrpoppy/evolve.py
@@ -6,22 +6,22 @@ import math
 import random
 
 import inspect
-import cPickle
 import scipy.integrate
 import numpy as np
 
+
 try:
     # try and import from the current path (for package usage or use as an uninstalled executable)
-    import distributions as dists
-    import galacticops as go
-    import beaming as beammodels
-    import populate
+    from . import distributions as dists
+    from . import galacticops as go
+    from . import beaming as beammodels
+    from . import populate
 
-    from population import Population
-    from pulsar import Pulsar
-    from survey import Survey
+    from .population import Population
+    from .pulsar import Pulsar
+    from .survey import Survey
 
-    from progressbar import ProgressBar
+    from .progressbar import ProgressBar
 except:
     try:
         # import from the installed package
@@ -109,30 +109,30 @@ def generate(ngen,
     pop.zscale = zscale
 
     if widthModel == 'kj07':
-        print "\tLoading KJ07 models...."
+        print("\tLoading KJ07 models....")
         kj_p_vals, kj_pdot_vals, kj_dists = beammodels.load_kj2007_models()
-        print "\tDone\n"
+        print("\tDone\n")
 
     if not nostdout:
-        print "\tGenerating evolved pulsars with parameters:"
-        print "\t\tngen = {0}".format(ngen)
-        print "\t\tUsing electron distn model {0}".format(
-                                        pop.electronModel)
-        print "\n\t\tPeriod mean, sigma = {0}, {1}".format(
+        print("\tGenerating evolved pulsars with parameters:")
+        print("\t\tngen = {0}".format(ngen))
+        print("\t\tUsing electron distn model {0}".format(
+                                        pop.electronModel))
+        print("\n\t\tPeriod mean, sigma = {0}, {1}".format(
                                                     pop.pmean,
-                                                    pop.psigma)
-        print "\t\tLuminosity mean, sigma = {0}, {1}".format(
+                                                    pop.psigma))
+        print("\t\tLuminosity mean, sigma = {0}, {1}".format(
                                                     pop.lummean,
-                                                    pop.lumsigma)
-        print "\t\tSpectral index mean, sigma = {0}, {1}".format(
+                                                    pop.lumsigma))
+        print("\t\tSpectral index mean, sigma = {0}, {1}".format(
                                                     pop.simean,
-                                                    pop.sisigma)
-        print "\t\tGalactic z scale height = {0} kpc".format(
-                                                    pop.zscale)
+                                                    pop.sisigma))
+        print("\t\tGalactic z scale height = {0} kpc".format(
+                                                    pop.zscale))
         if widthModel is None:
-            print "\t\tWidth {0}% ".format(duty)
+            print("\t\tWidth {0}% ".format(duty))
         else:
-            print "\t\tUsing Karastergiou & Johnston beam width model"
+            print("\t\tUsing Karastergiou & Johnston beam width model")
 
         # set up progress bar for fun :)
         prog = ProgressBar(min_value=0,
@@ -233,7 +233,7 @@ def generate(ngen,
             """
 
         else:
-            print "Undefined width model!"
+            print("Undefined width model!")
             sys.exit()
         # print width
         # print pulsar.period, width, pulsar.pdot
@@ -343,7 +343,7 @@ def generate(ngen,
                     # update the counter
                     if not nostdout:
                         prog.increment_amount()
-                        print prog, '\r',
+                        print(prog, '\r', end=' ')
                         sys.stdout.flush()
 
             else:
@@ -353,7 +353,7 @@ def generate(ngen,
                 # update the counter
                 if not nostdout:
                     prog.increment_amount()
-                    print prog, '\r',
+                    print(prog, '\r', end=' ')
                     sys.stdout.flush()
 
             # pulsar isn't dead, add to population!
@@ -367,20 +367,20 @@ def generate(ngen,
                 # update the counter
                 if not nostdout:
                     prog.increment_amount()
-                    print prog, '\r',
+                    print(prog, '\r', end=' ')
                     sys.stdout.flush()
 
     if not nostdout:
-        print "\n\n"
-        print "  Total pulsars = {0}".format(len(pop.population))
-        print "  Total detected = {0}".format(pop.ndet)
+        print("\n\n")
+        print("  Total pulsars = {0}".format(len(pop.population)))
+        print("  Total detected = {0}".format(pop.ndet))
 
         for surv in surveys:
-            print "\n  Results for survey '{0}'".format(surv.surveyName)
-            print "    Number detected = {0}".format(surv.ndet)
-            print "    Number too faint = {0}".format(surv.ntf)
-            print "    Number smeared = {0}".format(surv.nsmear)
-            print "    Number outside survey area = {0}".format(surv.nout)
+            print("\n  Results for survey '{0}'".format(surv.surveyName))
+            print("    Number detected = {0}".format(surv.ndet))
+            print("    Number too faint = {0}".format(surv.ntf))
+            print("    Number smeared = {0}".format(surv.nsmear))
+            print("    Number outside survey area = {0}".format(surv.nout))
 
     # save list of arguments into the pop
     try:

--- a/psrpoppy/evolve.py
+++ b/psrpoppy/evolve.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function, division, absolute_import
+
 import sys
 import argparse
 import math

--- a/psrpoppy/galacticops.py
+++ b/psrpoppy/galacticops.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function, division, absolute_import
+
 import os
 import sys
 

--- a/psrpoppy/orbit.py
+++ b/psrpoppy/orbit.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function, division, absolute_import
+
 
 class OrbitException(Exception):
     pass

--- a/psrpoppy/orbitalparams.py
+++ b/psrpoppy/orbitalparams.py
@@ -17,10 +17,10 @@ def test_1802_2124(pulsar):
     pulsar.inclination_degrees = 78.52
     pulsar.pulsar_mass_msolar = 1.24
 
-    print pulsar.gb, pulsar.gl
+    print(pulsar.gb, pulsar.gl)
     pulsar.gb = 0.61
     pulsar.gl = 4.38
-    print pulsar.gb, pulsar.gl
+    print(pulsar.gb, pulsar.gl)
     pulsar.galcoords = (0.49, 5.2, 0.04)
     pulsar.lum_1400 = 8.54
     pulsar.t_scatter = 0.0

--- a/psrpoppy/orbitalparams.py
+++ b/psrpoppy/orbitalparams.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function, division, absolute_import
+
 
 def test_1802_2124(pulsar):
 

--- a/psrpoppy/populate.py
+++ b/psrpoppy/populate.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function, division, absolute_import
+
 import sys
 import copy
 import argparse

--- a/psrpoppy/population.py
+++ b/psrpoppy/population.py
@@ -1,9 +1,14 @@
 #!/usr/bin/python
 
 import copy
-import cPickle
+import sys
 
 import numpy as np
+
+if sys.version_info[0] == 3:
+    import pickle
+else:
+    import cPickle as pickle
 
 
 class Population:
@@ -68,7 +73,7 @@ class Population:
         s = "Population model:"
 
         try:
-            for key, value in self.arguments.iteritems():
+            for key, value in self.arguments.items():
                 s = '\n\t'.join([s, "{0} = {1}".format(key, value)])
         except AttributeError:
             # handle old-fashioned models without self.arguments
@@ -102,7 +107,7 @@ class Population:
         """Write the population object to a file"""
 
         output = open(outf, 'wb')
-        cPickle.dump(self, output, 2)
+        pickle.dump(self, output, 2)
         output.close()
 
     def write_asc(self, outf):

--- a/psrpoppy/population.py
+++ b/psrpoppy/population.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function, division, absolute_import
+
 import copy
 import sys
 

--- a/psrpoppy/progressbar.py
+++ b/psrpoppy/progressbar.py
@@ -20,6 +20,8 @@
 #   http://code.activestate.com/recipes/168639/
 #
 
+from __future__ import print_function, division, absolute_import
+
 import os
 import sys
 

--- a/psrpoppy/progressbar.py
+++ b/psrpoppy/progressbar.py
@@ -95,29 +95,29 @@ class ProgressBar:
 
 
 def main():
-    print
+    print()
     limit = 1000000
 
-    print 'Example 1: Fixed Bar'
+    print('Example 1: Fixed Bar')
     prog = ProgressBar(0, limit, 77, mode='fixed')
     oldprog = str(prog)
-    for i in xrange(limit+1):
+    for i in range(limit+1):
         prog.update_amount(i)
         if oldprog != str(prog):
-            print prog, "\r",
+            print(prog, "\r", end=' ')
             sys.stdout.flush()
             oldprog = str(prog)
 
-    print '\n\n'
+    print('\n\n')
 
-    print 'Example 2: Dynamic Bar'
+    print('Example 2: Dynamic Bar')
     prog = ProgressBar(0, limit, 77, mode='dynamic', char='-')
     oldprog = str(prog)
-    for i in xrange(limit+1):
+    for i in range(limit+1):
         prog.increment_amount()
         if oldprog != str(prog):
-            print prog, "\r",
+            print(prog, "\r", end=' ')
             sys.stdout.flush()
             oldprog = str(prog)
 
-    print '\n\n'
+    print('\n\n')

--- a/psrpoppy/pulsar.py
+++ b/psrpoppy/pulsar.py
@@ -3,8 +3,8 @@
 import math
 import random
 
-from orbit import Orbit
-import galacticops as go
+from .orbit import Orbit
+from . import galacticops as go
 
 
 class PulsarException(Exception):
@@ -47,8 +47,9 @@ class Pulsar(Orbit):
         self.dm = dm
 
         # convert to -180->+180 range
-        if gl > 180.:
-            gl -= 360.
+        if gl is not None:
+            if gl > 180.:
+                gl -= 360.
 
         self.gl = gl
         self.gb = gb

--- a/psrpoppy/pulsar.py
+++ b/psrpoppy/pulsar.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function, division, absolute_import
+
 import math
 import random
 

--- a/psrpoppy/radialmodels.py
+++ b/psrpoppy/radialmodels.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function, division, absolute_import
+
 import os
 import sys
 import random

--- a/psrpoppy/radiometer.py
+++ b/psrpoppy/radiometer.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function, division, absolute_import
+
 import math
 
 

--- a/psrpoppy/survey.py
+++ b/psrpoppy/survey.py
@@ -8,10 +8,10 @@ import math
 import random
 from scipy.special import j1
 
-import galacticops as go
-from population import Population
-import radiometer as rad
-import degradation
+from . import galacticops as go
+from .population import Population
+from . import radiometer as rad
+from . import degradation
 
 
 class SurveyException(Exception):
@@ -274,7 +274,7 @@ class Survey:
                 # turn on AA
                 self.AA = True
             else:
-                print "Parameter '", a[1].strip(), "' not recognized!"
+                print("Parameter '", a[1].strip(), "' not recognized!")
 
         f.close()
 
@@ -455,37 +455,37 @@ class Survey:
         if pulsar.is_binary:
             # print "the pulsar is a binary!"
             if jerksearch:
-                print "jerk"
+                print("jerk")
                 gamma = degradation.gamma3(pulsar,
                                            self.tobs,
                                            1)
             elif accelsearch:
-                print "accel"
+                print("accel")
                 gamma = degradation.gamma2(pulsar,
                                            self.tobs,
                                            1)
             else:
-                print "norm"
+                print("norm")
                 gamma = degradation.gamma1(pulsar,
                                            self.tobs,
                                            1)
 
-                print "gamma harm1 = ", gamma
+                print("gamma harm1 = ", gamma)
 
                 gamma = degradation.gamma1(pulsar,
                                            self.tobs,
                                            2)
 
-                print "gamma harm2 = ", gamma
+                print("gamma harm2 = ", gamma)
                 gamma = degradation.gamma1(pulsar,
                                            self.tobs,
                                            3)
 
-                print "gamma harm3 = ", gamma
+                print("gamma harm3 = ", gamma)
                 gamma = degradation.gamma1(pulsar,
                                            self.tobs,
                                            4)
-                print "gamma harm4 = ", gamma
+                print("gamma harm4 = ", gamma)
 
         # return the S/N accounting for beam offset
         return sig_to_noise * degfac

--- a/psrpoppy/survey.py
+++ b/psrpoppy/survey.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function, division, absolute_import
+
 import os
 import sys
 import numpy as np


### PR DESCRIPTION
This PR coverts the Python files to Python 3. Primarily this has been achieved through using the [2to3](https://docs.python.org/3/library/2to3.html) package, although some manual editing has been performed to keep Python 2 compatibility.

I have tested this in a Python 3.8 environment and the following works:

```python
from psrpoppy import populate

pop = populate.generate(1038, 
                        surveyList=['PMSURV'],
                        radialDistType='lfl06',
                        siDistPars=[-1.41, 0.96], # non-standard SI distribution
                        duty_percent=6.,
                        electronModel='lmt85',
                        nostdout=True # switches off output to stdout
                       )
```

although there may be cases that might still fail.