### PR TITLE
Patch ne2001.f negative DMs

### DIFF
--- a/psrpoppy/fortran/ne2001.f
+++ b/psrpoppy/fortran/ne2001.f
@@ -172,10 +172,8 @@ c    .              ne1,ne2,negc,nelism,necN,nevN
 	sb=sin(b)
 	cb=cos(b)
 	limit=' '
-c	dstep=0.02			! Step size in kpc
+	dstep=0.01			! Step size in kpc
 c       dstep = min(h1, h2) / 10.       ! step size in terms of scale heights
-c	dstep=0.01
-        dstep=0.05
         if(ndir.lt.0) dtest=dist     
         if(ndir.ge.0) dtest=dmpsr/(n1h1/h1)   ! approximate test distance
         nstep = dtest / dstep	        ! approximate number of steps
@@ -380,7 +378,7 @@ c     .     d,x,y,z,ne,sm_term,whicharm,hitclump,hitvoid
 	endif
 	go to 999
 
-40	dmpsr=dm-dmstep*(d+0.5*dstep-dist)/dstep
+40	dmpsr=dm-dmstep*(d-dist)/dstep
         if(ncount .lt. 10) then 
 	   dstep = dstep / 10.
 	   go to 5

--- a/tests/test_ne2001.py
+++ b/tests/test_ne2001.py
@@ -1,0 +1,27 @@
+"""
+Integration tests NE2001
+"""
+import unittest
+import pytest
+import random
+import numpy as np
+import parameterized as ptzd
+from psrpoppy.galacticops import ne2001_dist_to_dm
+import psrpoppy
+
+class test_NE2001_DM_clumps(unittest.TestCase):
+    """
+    DM should never be negative, especially around DM 'clumps' it should increase
+    Remember to rebuild fortran SOs after checking out a new branch
+    """
+    
+    def test_positive_dm_around_NGC6334N(self):
+        lng = np.linspace(-179.9, 179.9, 1000)
+        lat = np.linspace(-89.9, 89.9, 1000)
+        dtrue = 1.63555909561 #kpc
+        gl = -8.82877643574 # deg
+        gb = 0.53676598385 # deg
+        dm_bslice = np.array([ne2001_dist_to_dm(dtrue, l, gb) for l in lng])
+        dm_lslice = np.array([ne2001_dist_to_dm(dtrue, gl, b) for b in lat])
+        stack = np.concatenate([dm_bslice, dm_lslice])
+        np.testing.assert_array_less(np.zeros(len(stack)), stack)


### PR DESCRIPTION
- Fixes #24 
- Add negative DM integration test
- Patch interpolation bug in NE2001
- Set `dstep=0.01` kpc