### PR TITLE
Patch make_mac.csh and make_linux.csh don't build libgamma.so and libgetseed.so

### DIFF
--- a/psrpoppy/fortran/make_linux.csh
+++ b/psrpoppy/fortran/make_linux.csh
@@ -8,5 +8,7 @@ $gf -shared -o libne2001.so -fno-second-underscore ne2001.o dm.o psr_ne.o dist.o
 $gf -shared -o libykarea.so -fno-second-underscore ykarea.o psrran.o
 $gf -shared -o libsla.so -fno-second-underscore galtfeq.o sla.o
 $gf -shared -o libvxyz.so -fno-second-underscore vxyz.o rkqc.o rk4.o
+$gf -shared -o libgamma.so -fno-second-underscore gamma.o
+$gf -shared -o libgetseed.so -fno-second-underscore getseed.o clock.o
 
 rm *.o

--- a/psrpoppy/fortran/make_mac.csh
+++ b/psrpoppy/fortran/make_mac.csh
@@ -11,6 +11,6 @@ $gf -dynamiclib -o libykarea.so -fno-second-underscore ykarea.o psrran.o
 $gf -dynamiclib -o libsla.so -fno-second-underscore galtfeq.o sla.o
 $gf -dynamiclib -o libvxyz.so -fno-second-underscore vxyz.o rkqc.o rk4.o
 $gf -dynamiclib -o libgamma.so -fno-second-underscore gamma.o
-
+$gf -dynamiclib -o libgetseed.so -fno-second-underscore getseed.o clock.o
 
 rm *.o


### PR DESCRIPTION
If the makefiles are going to be kept as an alternate build path to the `enscons` setupy.py, then they need to build the same fortran shared object libraries.