### PR TITLE
Add base-e log-normal pDistType to populate.py

### DIFF
--- a/psrpoppy/populate.py
+++ b/psrpoppy/populate.py
@@ -94,7 +94,7 @@ def generate(ngen,
     if velDistType not in ['gauss']:
        print "Unsupported velocity distribution: {0}".format(velDistType)
         
-    if pDistType not in ['lnorm', 'norm', 'cc97', 'lorimer12']:
+    if pDistType not in ['lnorm', 'norm', 'cc97', 'lorimer12', 'lnorm-e']:
         print "Unsupported period distribution: {0}".format(pDistType)
 
     if radialDistType not in ['lfl06', 'yk04', 'isotropic',
@@ -205,6 +205,9 @@ def generate(ngen,
             sys.exit()
         elif pop.pDistType == 'lorimer12':
             p.period = _lorimer2012_msp_periods()
+        elif pop.pDistType == 'lnorm-e':
+            p.period = np.random.lognormal(pop.pmean, pop.psigma)
+            
 
         # Draw perp  velocity components from independent normal dist           
         if pop.velDistType == 'gauss':
@@ -524,7 +527,7 @@ if __name__ == '__main__':
     # period distribution parameters
     parser.add_argument('-pdist', nargs=1, required=False, default=['lnorm'],
                         help='type of distribution to use for pulse periods',
-                        choices=['lnorm', 'norm', 'cc97', 'lorimer12'])
+                        choices=['lnorm', 'norm', 'cc97', 'lorimer12', 'lnorm-e'])
 
     parser.add_argument('-p', nargs=2, required=False, type=float,
                         default=[2.7, -0.34],

--- a/tests/test_populate_integration.py
+++ b/tests/test_populate_integration.py
@@ -91,12 +91,11 @@ class test_populate_generate_distributions(unittest.TestCase):
         Test base-e lnorm_e period sample mean and standard deviation match 
         pop.pmean and pop.psigma to 5 x standard error
         """
-        self.skipTest("This should be for a base-e log-normal distribution")
         random.seed(12345)
         mu_ln = 1.5
         sig_ln = 0.58
         pop = populate.generate(npsrs,
-                                pDistType='lnorm_e',
+                                pDistType='lnorm-e',
                                 pDistPars=[mu_ln, sig_ln],
                                 nostdout=True)
         periods = np.array([p.period for p in pop.population])


### PR DESCRIPTION
This feature addition supports the Lorimer et al. (2015) MSP spin period distribution, which is $\ln(P) \sim \mathcal{N}\left(1.5, (0.58)^2 \right)$. 